### PR TITLE
I182 frontend validation for modals

### DIFF
--- a/eta-meeting-organizer-frontend/src/app/meeting-room/components/meeting-room.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/meeting-room/components/meeting-room.component.ts
@@ -46,7 +46,7 @@ import { MeetingRoomService } from './../../shared/services/meeting-room.service
             <mat-icon class="projector-color" *ngIf="meetingRoom.projector===true">done</mat-icon>
         </ng-container>
         <ng-container matColumnDef="buildingName">
-          <th mat-header-cell *matHeaderCellDef> {{'meeting-room.buildingName' | translate}} </th>
+          <th mat-header-cell *matHeaderCellDef> {{'building.buildingName' | translate}} </th>
           <td mat-cell *matCellDef="let meetingRoom">
             {{meetingRoom.building?.buildingName}}</td>
         </ng-container>

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/building-register.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/building-register.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
@@ -23,21 +23,24 @@ import { BuildingService } from './../services/building.service';
       <mat-label>{{'building.buildingName' | translate}}</mat-label>
         <input type="text" name="city" formControlName="buildingName"
          matInput placeholder="{{'building.buildingName' | translate}}">
+         <mat-error>{{'validation.validate' | translate}}</mat-error>
     </mat-form-field>
     <br>
     <mat-form-field>
       <mat-label>{{'building.city' | translate}}</mat-label>
         <input type="text" name="city" formControlName="city" matInput placeholder="{{'building.city' | translate}}">
-    </mat-form-field>
+        <mat-error>{{'validation.validate' | translate}}</mat-error>
+      </mat-form-field>
     <br>
     <mat-form-field>
       <mat-label>{{'building.address' | translate}}</mat-label>
         <input  type="text" name="address" formControlName="address"
           matInput placeholder="{{'building.address' | translate}}">
+         <mat-error>{{'validation.validate' | translate}}</mat-error>
         </mat-form-field>
     <div>
       <button mat-button mat-dialog-close>{{'building.cancel' | translate}}</button>
-      <button mat-button mat-dialog-close type="submit" cdkFocusInitial
+      <button mat-button mat-dialog-close type="submit" cdkFocusInitial [disabled]="buildingForm.invalid"
       (click)="openSnackBar()">{{'building.saveButton' | translate}}</button>
     </div>
   </form>
@@ -58,9 +61,9 @@ export class BuildingRegisterComponent implements OnInit {
 
     public ngOnInit() {
       this.buildingForm = new FormGroup({
-      address : new FormControl(),
-      city : new FormControl(),
-      buildingName: new FormControl(),
+      address : new FormControl(undefined, Validators.required),
+      city : new FormControl(undefined, Validators.required),
+      buildingName: new FormControl(undefined, Validators.required),
       });
     }
 

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/building-update-dialog.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/building-update-dialog.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatSnackBar } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 import { Building } from '~/app/models/building.model';
@@ -13,20 +13,23 @@ import { BuildingService } from './../services/building.service';
   <mat-form-field>
       <mat-label>{{'building.buildingName' | translate}}</mat-label>
         <input matInput type="text" name="buildingName" formControlName="buildingName">
+        <mat-error>{{'validation.validate' | translate}}</mat-error>
     </mat-form-field>
     <br>
     <mat-form-field>
       <mat-label>{{'building.city' | translate}}</mat-label>
         <input matInput type="text" name="city" formControlName="city">
+        <mat-error>{{'validation.validate' | translate}}</mat-error>
     </mat-form-field>
     <br>
     <mat-form-field>
       <mat-label>{{'building.address' | translate}}</mat-label>
         <input matInput type="text" name="address" formControlName="address">
+        <mat-error>{{'validation.validate' | translate}}</mat-error>
         </mat-form-field>
     <div>
       <button mat-button mat-dialog-close>{{'building.cancel' | translate}}</button>
-      <button mat-button mat-dialog-close type="submit" cdkFocusInitial
+      <button mat-button mat-dialog-close type="submit" cdkFocusInitial [disabled]="buildingForm.invalid"
       (click)="openSnackBar()">{{'building.update' | translate}}</button>
     </div>
   </form>
@@ -52,9 +55,9 @@ export class BuildingUpdateDialogComponent implements OnInit {
   }
 
   public buildingForm: FormGroup = new FormGroup({
-    city: new FormControl(),
-    address: new FormControl(),
-    buildingName: new FormControl(),
+    city: new FormControl(undefined, Validators.required),
+    address: new FormControl(undefined, Validators.required),
+    buildingName: new FormControl(undefined, Validators.required),
   });
 
   public onSubmit() {

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/meeting-room-register.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/meeting-room-register.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { Building } from '~/app/models/building.model';
@@ -46,6 +46,7 @@ import { MeetingRoomService } from './../services/meeting-room.service';
        <mat-label>{{'meeting-room.text' | translate}}</mat-label>
          <input type="text" name="name" formControlName="name"
            matInput placeholder="{{'meeting-room.text' | translate}}">
+           <mat-error>{{'validation.validate' | translate}}</mat-error>
      </mat-form-field>
      <br>
 
@@ -54,6 +55,7 @@ import { MeetingRoomService } from './../services/meeting-room.service';
        <mat-label>{{'meeting-room.seats' | translate}}</mat-label>
          <input  type="number" name="numberOfSeats" formControlName="numberOfSeats"
            matInput placeholder="{{'meeting-room.seats' | translate}}">
+           <mat-error>{{'validation.validate' | translate}}</mat-error>
      </mat-form-field>
 
 <!-- projector -->
@@ -68,7 +70,7 @@ import { MeetingRoomService } from './../services/meeting-room.service';
 <!-- gombok -->
      <div class="space">
        <button mat-stroked-button mat-dialog-close style="float: left; color: primary;" >cancel</button>
-       <button mat-stroked-button mat-dialog-close type="submit" style="float: right;"
+       <button mat-stroked-button mat-dialog-close type="submit" style="float: right;" [disabled]="meetingForm.invalid"
          (click)="openSnackBar() "backgroundcolor="primary">
          Ok
        </button>
@@ -103,11 +105,11 @@ export class MeetingRoomRegisterComponent implements OnInit {
   }
 
   public meetingForm: FormGroup = new FormGroup({
-    building: new FormControl(''),
-    city : new FormControl(''), // kiszedve , Validators.required
-    name : new FormControl(''),
-    numberOfSeats : new FormControl(''),
-    projector : new FormControl(''),
+    building: new FormControl(undefined, Validators.required),
+    city : new FormControl(undefined, Validators.required),
+    name : new FormControl(undefined, Validators.required),
+    numberOfSeats : new FormControl(undefined, Validators.required),
+    projector : new FormControl(),
   });
 
   public getBuildings() {

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/meeting-room-update.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/meeting-room-update.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
@@ -30,6 +30,7 @@ import { MeetingRoomService } from '../services/meeting-room.service';
         <mat-label>{{'meeting-room.text' | translate}}</mat-label>
           <input type="text" name="name" formControlName="name"
             matInput placeholder="{{'meeting-room.text' | translate}}" [(ngModel)]="meetingRoom.name">
+            <mat-error>{{'validation.validate' | translate}}</mat-error>
       </mat-form-field>
       <br>
 
@@ -39,6 +40,7 @@ import { MeetingRoomService } from '../services/meeting-room.service';
           <input  type="number" name="numberOfSeats" formControlName="numberOfSeats"
           [(ngModel)]="meetingRoom.numberOfSeats"
             matInput placeholder="{{'meeting-room.seats' | translate}}">
+            <mat-error>{{'validation.validate' | translate}}</mat-error>
       </mat-form-field>
 
 <!-- projector -->
@@ -54,7 +56,7 @@ import { MeetingRoomService } from '../services/meeting-room.service';
       <div class="space">
         <button mat-stroked-button mat-dialog-close style="float: left; color: primary;" >cancel</button>
         <button mat-stroked-button mat-dialog-close type="submit" style="float: right;"
-          (click)="openSnackBar() "backgroundcolor="primary">
+          (click)="openSnackBar() "backgroundcolor="primary" [disabled]="meetingForm.invalid">
           Ok
         </button>
       </div>
@@ -83,8 +85,8 @@ export class MeetingRoomUpdateComponent implements OnInit {
   }
 
   public meetingForm: FormGroup = new FormGroup({
-    name : new FormControl(''),
-    numberOfSeats : new FormControl(''),
+    name : new FormControl(undefined, Validators.required),
+    numberOfSeats : new FormControl(undefined, Validators.required),
     projector : new FormControl(''),
   });
 

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/user-verification-dialog.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/user-verification-dialog.ts
@@ -18,7 +18,7 @@ import { TranslateService } from '@ngx-translate/core';
   </mat-dialog-content>
   <mat-dialog-actions>
     <button mat-raised-button mat-dialog-close>{{'user-verification-dialog.cancel' | translate}}</button>
-    <button mat-raised-button mat-dialog-close={{choosenRole}} color="primary" [disabled]="choosenRole === undefined"
+    <button mat-raised-button mat-dialog-close={{choosenRole}} color="primary" [disabled]="!choosenRole"
     (click)="openSnackBar()">{{'user-verification-dialog.setRole' | translate}}</button>
   </mat-dialog-actions>
   `

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/user-verification-dialog.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/user-verification-dialog.ts
@@ -9,7 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
   <mat-dialog-content>
   <mat-form-field appearance="fill">
     <mat-label>{{'user-verification-dialog.roles' | translate}}</mat-label>
-    <mat-select [(value)]="choosenRole">
+    <mat-select [(value)]="choosenRole" required>
       <mat-option value="ADMIN">{{'user-verification-dialog.admin' | translate}}</mat-option>
       <mat-option value="USER">{{'user-verification-dialog.user' | translate}}</mat-option>
       <mat-option value="READER">{{'user-verification-dialog.reader' | translate}}</mat-option>
@@ -18,7 +18,7 @@ import { TranslateService } from '@ngx-translate/core';
   </mat-dialog-content>
   <mat-dialog-actions>
     <button mat-raised-button mat-dialog-close>{{'user-verification-dialog.cancel' | translate}}</button>
-    <button mat-raised-button mat-dialog-close={{choosenRole}} color="primary"
+    <button mat-raised-button mat-dialog-close={{choosenRole}} color="primary" [disabled]="choosenRole === undefined"
     (click)="openSnackBar()">{{'user-verification-dialog.setRole' | translate}}</button>
   </mat-dialog-actions>
   `

--- a/eta-meeting-organizer-frontend/src/assets/i18n/en.json
+++ b/eta-meeting-organizer-frontend/src/assets/i18n/en.json
@@ -110,5 +110,8 @@
     "building": "Building",
     "meeting-room": "Meetingroom",
     "own-appointments": "Own Appointments"
+  },
+  "validation": {
+    "validate": "You must fill out this field!"
   }
 }

--- a/eta-meeting-organizer-frontend/src/assets/i18n/hu.json
+++ b/eta-meeting-organizer-frontend/src/assets/i18n/hu.json
@@ -110,5 +110,8 @@
     "building": "Épület",
     "meeting-room": "Tárgyaló",
     "own-appointments": "Saját Foglalásaim"
+  },
+  "validation": {
+    "validate": "A mező kitöltése kötelező!"
   }
 }

--- a/eta-meeting-organizer-frontend/src/theme.scss
+++ b/eta-meeting-organizer-frontend/src/theme.scss
@@ -9,7 +9,7 @@
 
 // Fonts
 @import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500');
-     
+
 $fontConfig: (
   display-4: mat-typography-level(112px, 112px, 300, 'Roboto', -0.0134em),
   display-3: mat-typography-level(56px, 56px, 400, 'Roboto', -0.0089em),
@@ -196,10 +196,10 @@ body {
 }
 
 $mat-warn: (
-  main: #f3f5ed,
-  lighter: #fbfcfa,
-  darker: #edf0e5,
-  200: #f3f5ed, // For slide toggle,
+  main: #e64b3a,
+  lighter: #f8c9c4,
+  darker: #db3325,
+  200: #e64b3a, // For slide toggle,
   contrast : (
     main: $dark-primary-text,
     lighter: $dark-primary-text,


### PR DESCRIPTION
#182 
Elkészítettem a validálást a következőkhöz.
- tárgyaló regisztráció
- tárgyaló frissítés
- épület regisztráció 
- épület frissítés
- user validálás
 A theme.scss -ben színváltozás történt hogy az értesítő szöveg látható legyen az felhasználó számára ha nem tölt ki valamit. A submit gombokat letiltva lesznek mindaddig amíg nem tölti ki az összes kötelező mezőt.

**A frontend issuek közül ez kellene bemenjen a masterbe először, hogy Peti tudja finomítani a #181 issuban a térközöket az input fieldek között mert most hogy ha nincs kitöltve és validációs hiba message-e kiíródik így közelinek látszanak az input mezők** 