### PR TITLE
I227 calendar coloring

### DIFF
--- a/eta-meeting-organizer-frontend/src/_globals.scss
+++ b/eta-meeting-organizer-frontend/src/_globals.scss
@@ -10,3 +10,12 @@ body {
 .w-50 {
   width: 50%;
 }
+
+.fc-toolbar.fc-header-toolbar {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+
+a.fc-time-grid-event.fc-event {
+  cursor: pointer;
+}

--- a/eta-meeting-organizer-frontend/src/_globals.scss
+++ b/eta-meeting-organizer-frontend/src/_globals.scss
@@ -19,3 +19,13 @@ body {
 a.fc-time-grid-event.fc-event {
   cursor: pointer;
 }
+
+div.fc-title {
+  font-size: 1.8em;
+  text-align: center;
+  word-break: break-all;
+}
+
+.fc-time-grid-event .fc-time {
+  text-align: center;
+}

--- a/eta-meeting-organizer-frontend/src/app/calendar/components/calendar.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/calendar/components/calendar.component.ts
@@ -172,8 +172,12 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   }
   public getInfo(eventInput: EventInput) {
     let isMeetingRoomView = false;
+    let isAdmin = false;
     if (!this.checked && eventInput.event.extendedProps.userId !== this.userToken.sub) {
       isMeetingRoomView = true;
+    }
+    if (this.userToken.role === 'ADMIN') {
+      isAdmin = true;
     }
     const dialogRef = this.dialog.open(ReservationInfoComponent, {
       width: '400px',
@@ -187,7 +191,8 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges, OnDe
         end: eventInput.event.end,
         title: eventInput.event.title,
         summary: eventInput.event.extendedProps.summary,
-        meetingRoomView: isMeetingRoomView
+        meetingRoomView: isMeetingRoomView,
+        admin: isAdmin
       },
     });
     dialogRef.componentInstance.closeOutput.pipe(takeUntil(this.destroy$))

--- a/eta-meeting-organizer-frontend/src/app/calendar/components/calendar.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/calendar/components/calendar.component.ts
@@ -153,8 +153,8 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   public bookDialog(event: EventInput) {
     const dialogRef = this.dialog.open(ReservationBookingComponent, {
       disableClose: true,
-      height: '60%',
-      width: '25%',
+      height: '80%',
+      width: '35%',
       data: {
         userId: this.userToken.sub,
         meetingRoomId: this.meetingRoom.id,

--- a/eta-meeting-organizer-frontend/src/app/models/event.model.ts
+++ b/eta-meeting-organizer-frontend/src/app/models/event.model.ts
@@ -9,4 +9,5 @@ export interface EventElement {
   overlap: boolean;
   title: string;
   summary: string;
+  meetingRoomView: boolean;
 }

--- a/eta-meeting-organizer-frontend/src/app/models/event.model.ts
+++ b/eta-meeting-organizer-frontend/src/app/models/event.model.ts
@@ -10,4 +10,5 @@ export interface EventElement {
   title: string;
   summary: string;
   meetingRoomView: boolean;
+  admin: string;
 }

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-book.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-book.component.ts
@@ -47,7 +47,7 @@ import { ReservationService } from '../services/reservation.service';
    <form [formGroup]="reservationBookingForm" (ngSubmit)="onSubmit()">
      <mat-form-field>
        <mat-label>{{'reservation.title' | translate}}</mat-label>
-         <input type="text" name="title" formControlName="title"
+         <input type="text" name="title" formControlName="title" maxlength="20"
           matInput placeholder="{{'reservation.title' | translate}}">
           <br>
           <mat-error>{{'validation.validate' | translate}}</mat-error>

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-book.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-book.component.ts
@@ -20,7 +20,7 @@ import { ReservationService } from '../services/reservation.service';
     text-align: center;
   }
   .align-content{
-    height: 75%;
+    height: 90%;
     font-size: 160%;
     margin: 0 auto;
     text-align: center;
@@ -37,6 +37,9 @@ import { ReservationService } from '../services/reservation.service';
     border-color: black;
     font-size: 100%;
   }
+  textarea {
+    rows: 4;
+  }
 `],
  template: `
  <mat-dialog-content class="align-title">{{'reservation.head' | translate}}</mat-dialog-content>
@@ -46,19 +49,26 @@ import { ReservationService } from '../services/reservation.service';
        <mat-label>{{'reservation.title' | translate}}</mat-label>
          <input type="text" name="title" formControlName="title"
           matInput placeholder="{{'reservation.title' | translate}}">
+          <br>
+          <mat-error>{{'validation.validate' | translate}}</mat-error>
      </mat-form-field>
      <br>
      <mat-form-field>
        <mat-label>{{'reservation.summary' | translate}}</mat-label>
-         <input  type="text" name="summary" formControlName="summary"
-           matInput placeholder="{{'reservation.summary' | translate}}">
+       <textarea matInput name="summary" formControlName="summary" rows="9" maxlength="255"
+       placeholder="{{'reservation.summary' | translate}}"></textarea>
+         <br>
+           <mat-error>{{'validation.validate' | translate}}</mat-error>
        </mat-form-field>
+     <br>
+     <br>
      <br>
      <mat-dialog-actions>
        <button
        mat-raised-button
        type="submit"
        [mat-dialog-close]
+       [disabled]="reservationBookingForm.invalid"
        cdkFocusInitial
        color="primary"
        (click)="openSnackBar()"
@@ -97,11 +107,15 @@ export class ReservationBookingComponent implements OnInit {
     private readonly _snackBar: MatSnackBar,
     private readonly translate: TranslateService,
     public datepipe: DatePipe) {
+      dialogRef.backdropClick()
+      .subscribe(() => {
+        dialogRef.close();
+      });
   }
 
   public ngOnInit() {
     this.reservationBookingForm = new FormGroup({
-    title : new FormControl('', Validators.required ),
+    title : new FormControl('', Validators.required),
     summary : new FormControl('', Validators.required),
     });
   }

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
@@ -93,7 +93,7 @@ import { ReservationUpdateComponent } from './reservation-update.component';
       <br>
     <mat-dialog-actions>
       <button mat-raised-button color="warn"
-      *ngIf="!data.meetingRoomView"
+      *ngIf="!data.meetingRoomView || data.admin"
       (click)="deleteDialog()">{{'reservation.delete' | translate}}</button>
     </mat-dialog-actions>
 </mat-dialog-content>`,

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
@@ -19,7 +19,7 @@ import { ReservationUpdateComponent } from './reservation-update.component';
     text-align: center;
   }
   .align-content{
-    height: auto;
+    height: 16cm;
     font-size: 120%;
     margin: 0 auto;
     text-align: center;
@@ -34,15 +34,20 @@ import { ReservationUpdateComponent } from './reservation-update.component';
   mat-label {
     font-weight: bold;
   }
+  .example-card {
+    word-break: break-all;
+    max-width: 300px;
+  }
   `],
  template: `
 <mat-dialog-content class="align-title">{{'reservation.summary' | translate}}</mat-dialog-content>
 <mat-dialog-content class="align-content">
-  <mat-card class="align-content">
+  <mat-card class="align-content" class="example-card">
     <div class="data">
       <mat-label>{{'reservation.meetingroom' | translate}}</mat-label>
       <br>
       {{ data.meetingRoomName }}
+      <br>
       <br>
       <mat-divider></mat-divider>
       <br>
@@ -50,17 +55,23 @@ import { ReservationUpdateComponent } from './reservation-update.component';
       <br>
       {{ data.title }}
       <br>
+      <br>
       <mat-divider></mat-divider>
       <br>
       <mat-label>{{'reservation.summary' | translate}}</mat-label>
       <br>
+      <mat-card-content>
+      <p>
       {{ data.summary }}
+      </p>
+      </mat-card-content>
       <br>
       <mat-divider></mat-divider>
       <br>
       <mat-label>{{'reservation.startDate' | translate}}</mat-label>
       <br>
       {{ data.start | date : 'y.MM.dd. HH:mm'}}
+      <br>
       <br>
       <mat-divider></mat-divider>
       <br>
@@ -114,6 +125,7 @@ export class ReservationInfoComponent {
 
   public updateDialog() {
     const dialogRef = this.dialog.open(ReservationUpdateComponent, {
+      height: '80%',
       width: '400px',
       data: this.data
     });

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-info.component.ts
@@ -71,6 +71,7 @@ import { ReservationUpdateComponent } from './reservation-update.component';
 </mat-card>
 <mat-dialog-actions>
     <button mat-raised-button
+    *ngIf="!data.meetingRoomView"
       (click)="updateDialog()" color="primary">{{'reservation.modify' | translate}}</button>
     </mat-dialog-actions>
       <br>
@@ -81,6 +82,7 @@ import { ReservationUpdateComponent } from './reservation-update.component';
       <br>
     <mat-dialog-actions>
       <button mat-raised-button color="warn"
+      *ngIf="!data.meetingRoomView"
       (click)="deleteDialog()">{{'reservation.delete' | translate}}</button>
     </mat-dialog-actions>
 </mat-dialog-content>`,

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-time-update.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-time-update.ts
@@ -22,6 +22,8 @@ import { ReservationService } from '../services/reservation.service';
     font-size: 120%;
     margin: 0 auto;
     text-align: center;
+    word-break: break-all;
+
   }
   button {
     width: 80%;

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-time-update.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-time-update.ts
@@ -13,7 +13,6 @@ import { ReservationService } from '../services/reservation.service';
   styles: [`
   .align-title {
     padding-top: 5%;
-    height: 100%;
     margin: 0 auto;
     font-size: 250%;
     text-align: center;
@@ -57,7 +56,6 @@ class="align-title">{{'reservation-time-change-dialog.head' | translate}}</mat-d
       <br>
       {{ data.end | date : 'y.MM.dd. HH:mm'}}
 </div>
-</mat-card>
 <mat-dialog-actions>
     <button mat-raised-button
       (click)="updateTime()" color="primary">{{'reservation.modify' | translate}}</button>
@@ -66,7 +64,8 @@ class="align-title">{{'reservation-time-change-dialog.head' | translate}}</mat-d
     <mat-dialog-actions>
       <button mat-raised-button color="accent"
       (click)="close()">{{'reservation.quit' | translate}}</button>
-    </mat-dialog-actions>
+</mat-dialog-actions>
+</mat-card>
 </mat-dialog-content>`,
 })
 

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-update.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-update.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,14 +12,13 @@ import { ReservationService } from '../services/reservation.service';
   styles: [`
   .align-title {
     padding-top: 5%;
-    padding-bottom: 5%;
-    height: 150px;
+    height: 100px;
     margin: 0 auto;
     font-size: 250%;
     text-align: center;
   }
   .align-content{
-    height: 10cm;
+    height: 13.5cm;
     font-size: 160%;
     margin: 0 auto;
     text-align: center;
@@ -49,9 +48,11 @@ import { ReservationService } from '../services/reservation.service';
     </mat-form-field>
     <br>
     <mat-form-field>
-      <mat-label>{{'reservation.summary' | translate}}</mat-label>
-        <input matInput type="text" name="summary" formControlName="summary">
-        <mat-error>{{'validation.validate' | translate}}</mat-error>
+    <mat-label>{{'reservation.summary' | translate}}</mat-label>
+       <textarea matInput name="summary" formControlName="summary" rows="9" maxlength="255"
+       placeholder="{{'reservation.summary' | translate}}"></textarea>
+         <br>
+           <mat-error>{{'validation.validate' | translate}}</mat-error>
     </mat-form-field>
     <mat-dialog-actions>
     <button mat-raised-button mat-dialog-close type="submit"
@@ -70,8 +71,8 @@ export class ReservationUpdateComponent implements OnInit {
   public reservationToPost: ReservationToPost = {} as ReservationToPost;
 
   public reservationUpdateForm: FormGroup = new FormGroup({
-    title : new FormControl(''),
-    summary : new FormControl(''),
+    title : new FormControl('', Validators.required),
+    summary : new FormControl('', Validators.required),
   });
 
   constructor(

--- a/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-update.component.ts
+++ b/eta-meeting-organizer-frontend/src/app/shared/Modals/reservation-update.component.ts
@@ -43,7 +43,7 @@ import { ReservationService } from '../services/reservation.service';
   <form [formGroup]="reservationUpdateForm" (ngSubmit)="onSubmit()">
   <mat-form-field>
       <mat-label>{{'reservation.title' | translate}}</mat-label>
-        <input matInput type="text" name="title" formControlName="title">
+        <input matInput type="text" name="title" formControlName="title" maxlength="20">
         <mat-error>{{'validation.validate' | translate}}</mat-error>
     </mat-form-field>
     <br>


### PR DESCRIPTION
#227 
A naptárnézetben az eventek kétszínűek lettek (saját foglalás, más felhasználó foglalása). Az event-ek szerepkörök szerint törölhetők, módosíthatók. Az eventek kinézete szintén változott. A naptár késznek tekinthető ezáltal, de még az események felvételénél szeretnénk e-mail kiküldeni megadott embereknek, az egy másik issue-ban kerül implementálásra.